### PR TITLE
add optimizer state_dict and memory in save/load

### DIFF
--- a/DDPG/buffer.py
+++ b/DDPG/buffer.py
@@ -1,7 +1,8 @@
+import os
 import numpy as np
 
 class ReplayBuffer():
-    def __init__(self, max_size, input_shape, n_actions):
+    def __init__(self, max_size, input_shape, n_actions, name = "memory", chkpt_dir='tmp/ddpg'):
         self.mem_size = max_size
         self.mem_cntr = 0
         self.state_memory = np.zeros((self.mem_size, *input_shape))
@@ -9,6 +10,10 @@ class ReplayBuffer():
         self.action_memory = np.zeros((self.mem_size, n_actions))
         self.reward_memory = np.zeros(self.mem_size)
         self.terminal_memory = np.zeros(self.mem_size, dtype=np.bool)
+        self.name = name
+        self.checkpoint_dir = chkpt_dir
+        self.checkpoint_file = os.path.join(self.checkpoint_dir, self.name)
+        self.checkpoint_file_best = os.path.join(self.checkpoint_dir, "best", self.name)    #places the same filenames, but in a sub-folder called "best"
 
     def store_transition(self, state, action, reward, state_, done):
         index = self.mem_cntr % self.mem_size
@@ -33,4 +38,29 @@ class ReplayBuffer():
 
         return states, actions, rewards, states_, dones
 
+    def save_memory(self):
+        print('... saving memory ...')
+        np.savez(self.checkpoint_file, 
+                states=self.state_memory, 
+                actions=self.action_memory, 
+                rewards=self.reward_memory, 
+                states_=self.new_state_memory, 
+                dones=self.terminal_memory)
 
+    def save_best_memory(self):
+        print('... saving best memory ...')
+        np.savez(self.checkpoint_file_best, 
+                states=self.state_memory, 
+                actions=self.action_memory, 
+                rewards=self.reward_memory, 
+                states_=self.new_state_memory, 
+                dones=self.terminal_memory)
+
+    def load_memory(self):
+        print('... loading memory ...')
+        saved_data = np.load(self.checkpoint_file)
+        self.state_memory = saved_data['states']
+        self.action_memory = saved_data['actions']
+        self.reward_memory = saved_data['rewards']
+        self.new_state_memory = saved_data['states_']
+        self.terminal_memory = saved_data['dones']

--- a/DDPG/ddpg_torch.py
+++ b/DDPG/ddpg_torch.py
@@ -16,7 +16,7 @@ class Agent():
         self.alpha = alpha
         self.beta = beta
 
-        self.memory = ReplayBuffer(max_size, input_dims, n_actions)
+        self.memory = ReplayBuffer(max_size, input_dims, n_actions, name="memory")
 
         self.noise = OUActionNoise(mu=np.zeros(n_actions))
 
@@ -51,12 +51,14 @@ class Agent():
         self.target_actor.save_checkpoint()
         self.critic.save_checkpoint()
         self.target_critic.save_checkpoint()
+        self.memory.save_memory()       #save the entire replaybuffer to facilitate resume training
 
     def load_models(self):
         self.actor.load_checkpoint()
         self.target_actor.load_checkpoint()
         self.critic.load_checkpoint()
         self.target_critic.load_checkpoint()
+        self.memory.load_memory()       #load the entire replaybuffer to facilitate resume training
 
     def learn(self):
         if self.memory.mem_cntr < self.batch_size:


### PR DESCRIPTION
In order to facilitate re-training after saving, it is necessary to save/load not just actor and target actor, critic and target critic, but also their respective optimizers. Furthermore, the replay buffer is also saved/loaded to ensure that the same memories are used, rather than starting from zeros. (which can affect greatly since DDPG also relies on replay buffer for learning).

This is my first time putting a pull request. I hope you don't find me a busybody to add these codes. Please let me know how else I can improve on my pull request process. 

Cheers